### PR TITLE
+Fix:  add "pnpm exec"  to  "pb:start" script => it works now

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./jsconfig.json --watch",
 		"lint": "prettier --check . && eslint .",
 		"format": "prettier --write .",
-		"pb:start": "./POCKETBASE/pocketbase serve"
+		"pb:start": "pnpm exec ./POCKETBASE/pocketbase serve"
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-auto": "^3.0.0",


### PR DESCRIPTION
Hi,
entering "pnpm pb:start" caused this error:
```
$ pnpm pb:start

> pocketbase-things@0.0.1 pb:start C:\Users\Z\sk-pb-todos
> ./POCKETBASE/pocketbase serve

'.' is not recognized as an internal or external command,
operable program or batch file.
 ELIFECYCLE  Command failed with exit code 1.
```
Adding "pnpm exec" to the pb:start script fixed it.